### PR TITLE
Automatically accept privacy in Esse3

### DIFF
--- a/src/it/fdev/unisaconnect/FragmentEsse3Web.java
+++ b/src/it/fdev/unisaconnect/FragmentEsse3Web.java
@@ -46,7 +46,8 @@ public class FragmentEsse3Web extends MySimpleFragment {
 	private SharedPrefDataManager mDataManager;
 	private boolean didSendLoginData = false;
 	private Fragment thisFragment;
-	
+    private boolean acceptedPrivacy = false;
+
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View mainView = (View) inflater.inflate(R.layout.web_fragment, container, false);
@@ -112,7 +113,7 @@ public class FragmentEsse3Web extends MySimpleFragment {
 		webSettings.setLoadsImagesAutomatically(true);
 		webSettings.setBuiltInZoomControls(true);
 		webSettings.setSupportZoom(true);
-		webSettings.setJavaScriptEnabled(false);
+		webSettings.setJavaScriptEnabled(true);
 		
 		mWebView.setWebChromeClient(new WebChromeClient() {
 			public void onProgressChanged(WebView view, int progress) {
@@ -168,6 +169,10 @@ public class FragmentEsse3Web extends MySimpleFragment {
 				progressBar.setVisibility(View.GONE);
 				mActivity.setLoadingVisible(false, false);
 				didSendLoginData = false;
+                if(!acceptedPrivacy) {
+                    view.loadUrl("javascript:cookies.set()");
+                    acceptedPrivacy = true;
+                }
 			}
 		});
 


### PR DESCRIPTION
Ciao, questo dovrebbe risolvere l'odiosa presenza del banner per la privacy (vedi #7 ). Non ho provato la soluzione perché non riesco a installare il progetto per avere una build eseguibile.

La soluzione dovrebbe automaticamente accettare le condizioni per la privacy e impostare un cookie facendo nascondere il banner che occupa gran parte dello schermo all'interno della sezione il mio esse 3.
